### PR TITLE
Speed up firmware library update

### DIFF
--- a/src/managers/commandstoxrpmgr.ts
+++ b/src/managers/commandstoxrpmgr.ts
@@ -428,10 +428,19 @@ export class CommandToXRPMgr {
             }
         }
 
+        // Build each unique destination directory once instead of once per file.
+        const uniqueDirs = new Set<string>();
+        for (const [deviceDest] of urls) {
+            uniqueDirs.add(deviceDest.substring(0, deviceDest.lastIndexOf('/')));
+        }
+        for (const dir of uniqueDirs) {
+            await this.buildPath(dir);
+        }
+
         for (let i = 0; i < urls.length; i++) {
             const [deviceDest, sourceRel] = urls[i];
             const fetchUrl = resolveSourceUrl(sourceRel) + '?version=' + cacheToken;
-            await this.uploadFile(deviceDest, await this.downloadFile(fetchUrl));
+            await this.uploadFile(deviceDest, await this.downloadFile(fetchUrl), false, false);
             emitProgress(cur_percent);
             cur_percent += percent_per;
         }
@@ -765,13 +774,15 @@ export class CommandToXRPMgr {
     }
 
 
-    async uploadFile(filePath: string, fileContents: string | Uint8Array, usePercent: boolean = false) {
+    async uploadFile(filePath: string, fileContents: string | Uint8Array, usePercent: boolean = false, ensurePath: boolean = true) {
         if (this.BUSY == true) {
             return true;
         }
 
-        const pathToFile = filePath.substring(0, filePath.lastIndexOf('/'));
-        await this.buildPath(pathToFile);
+        if (ensurePath) {
+            const pathToFile = filePath.substring(0, filePath.lastIndexOf('/'));
+            await this.buildPath(pathToFile);
+        }
 
         this.BUSY = true;
         if (usePercent)

--- a/src/managers/commandstoxrpmgr.ts
+++ b/src/managers/commandstoxrpmgr.ts
@@ -423,7 +423,8 @@ export class CommandToXRPMgr {
         };
         for (const dir of wipeDirs) {
             if (urls.some(([dest]) => destStartsWithDir(dest, dir))) {
-                await this.deleteFileOrDir(dir);
+                // Skip the per-delete FS-tree walk; getOnBoardFSTree() runs once at the end.
+                await this.deleteFileOrDir(dir, false);
             }
         }
 
@@ -962,7 +963,7 @@ export class CommandToXRPMgr {
     
 
     // Given a path, delete it on XRP
-    async deleteFileOrDir(path: string) {
+    async deleteFileOrDir(path: string, refreshTree: boolean = true) {
         if (path != undefined) {
             if (this.BUSY == true) {
                 return;
@@ -996,7 +997,9 @@ export class CommandToXRPMgr {
             this.BUSY = false;
 
             // Make sure to update the filesystem after modifying it
-            await this.getOnBoardFSTree();
+            if (refreshTree) {
+                await this.getOnBoardFSTree();
+            }
             //window.setPercent?.(100); TODO:
             //window.resetPercentDelay?.();
         }


### PR DESCRIPTION
Two small fixes to cut protocol overhead from the library copy phase:

- Skip the full filesystem walk after each wiped lib directory; the tree is refreshed once at the end.
- Build each unique destination directory once up front instead of once per file (~28 fewer raw-REPL round trips).

No behavior change for other callers; new parameters default to the old behavior.