### PR TITLE
Add firmware staging to deploy and release workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,16 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Checkout firmware-loader content (XRP_Firmware)
+              uses: actions/checkout@v4
+              with:
+                  # Change repository/ref to a fork or branch to ship unreleased firmware
+                  repository: Open-STEM/XRP_Firmware
+                  path: xrp-firmware
+            - name: Stage firmware-loader boards content
+              run: |
+                  rm -rf public/firmware-loader/boards
+                  cp -r xrp-firmware/boards public/firmware-loader/boards
             - name: Set up Node ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,19 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            # Same staging as deploy.yml: the /firmware-loader/boards content
+            # is never checked in, so pull it from the firmware repo before
+            # the build or the released site 404s on all firmware loader data.
+            - name: Checkout firmware-loader content (XRP_Firmware)
+              uses: actions/checkout@v4
+              with:
+                  # Change repository/ref to a fork or branch to ship unreleased firmware
+                  repository: Open-STEM/XRP_Firmware
+                  path: xrp-firmware
+            - name: Stage firmware-loader boards content
+              run: |
+                  rm -rf public/firmware-loader/boards
+                  cp -r xrp-firmware/boards public/firmware-loader/boards
             - name: Set up Node ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
Right now the Firmware loader 404s when hosted on GitHub pages and when downloaded from releases.

With this PR both deploy and release workflows now checkout the XRP_Firmware repository and stage the firmware boards content into the public/firmware-loader/boards directory before building. This ensures the firmware-loader has the necessary board data and prevents 404s on the released site.

I have not tested this extensively! Experimental...