### PR TITLE
Checkout latest XRP_Firmware release in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,21 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Resolve latest XRP_Firmware release
+              id: firmware
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TAG=$(gh release view --repo Open-STEM/XRP_Firmware --json tagName --jq .tagName)
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                  echo "Using XRP_Firmware release $TAG"
             - name: Checkout firmware-loader content (XRP_Firmware)
               uses: actions/checkout@v4
               with:
-                  # Change repository/ref to a fork or branch to ship unreleased firmware
+                  # Pull the latest published release. To ship unreleased firmware, override
+                  # repository/ref to a fork or branch.
                   repository: Open-STEM/XRP_Firmware
+                  ref: ${{ steps.firmware.outputs.tag }}
                   path: xrp-firmware
             - name: Stage firmware-loader boards content
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,21 @@ jobs:
             # Same staging as deploy.yml: the /firmware-loader/boards content
             # is never checked in, so pull it from the firmware repo before
             # the build or the released site 404s on all firmware loader data.
+            - name: Resolve latest XRP_Firmware release
+              id: firmware
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TAG=$(gh release view --repo Open-STEM/XRP_Firmware --json tagName --jq .tagName)
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                  echo "Using XRP_Firmware release $TAG"
             - name: Checkout firmware-loader content (XRP_Firmware)
               uses: actions/checkout@v4
               with:
-                  # Change repository/ref to a fork or branch to ship unreleased firmware
+                  # Pull the latest published release. To ship unreleased firmware, override
+                  # repository/ref to a fork or branch.
                   repository: Open-STEM/XRP_Firmware
+                  ref: ${{ steps.firmware.outputs.tag }}
                   path: xrp-firmware
             - name: Stage firmware-loader boards content
               run: |


### PR DESCRIPTION
Add steps to deploy.yml and release.yml that resolve the latest Open-STEM/XRP_Firmware release via the gh CLI and set actions/checkout to use that tag for the xrp-firmware path.