### PR TITLE
Use sessionStorage for xrpNanoSeen flag

### DIFF
--- a/src/components/dialogs/firmware-loaderdlg.tsx
+++ b/src/components/dialogs/firmware-loaderdlg.tsx
@@ -348,7 +348,7 @@ function FirmwareLoaderDlg({ toggleDialog }: FirmwareLoaderDlgProps) {
                 {!installContext && !loading && !loadError && !unavailableProject && hasBoards && (
                     <div className={selectionGridClass}>
                         {doc!.boards
-                            .filter((board) => board.id !== 'xrp-nano' || localStorage.getItem('xrpNanoSeen') === 'true')
+                            .filter((board) => board.id !== 'xrp-nano' || sessionStorage.getItem('xrpNanoSeen') === 'true')
                             .map((board) => (
                             <SelectionCard
                                 key={board.id}

--- a/src/managers/commandstoxrpmgr.ts
+++ b/src/managers/commandstoxrpmgr.ts
@@ -198,9 +198,10 @@ export class CommandToXRPMgr {
                 } else if (hiddenLines[1].includes('RP2040')) {
                     this.PROCESSOR = 2040;
                     this.is_NanoXRP = hiddenLines[1].includes('NanoXRP');
-                    // Sticky flag: once we've ever connected to a NanoXRP, the
-                    // firmware loader shows the NanoXRP card from then on.
-                    if (this.is_NanoXRP) localStorage.setItem('xrpNanoSeen', 'true');
+                    // Session-scoped flag: once we've connected to a NanoXRP in
+                    // this session, the firmware loader shows the NanoXRP card
+                    // for the rest of the session. Cleared on a fresh page load.
+                    if (this.is_NanoXRP) sessionStorage.setItem('xrpNanoSeen', 'true');
                     this.connection?.setNanoXRP(this.is_NanoXRP);
                 }
                 if(hiddenLines[1].includes('XRP')){ //is this an XRP version of microPython?


### PR DESCRIPTION
Replace localStorage with sessionStorage for the xrpNanoSeen flag to make it session-scoped. This ensures the flag is cleared on a fresh page load rather than persisting indefinitely. Updated the related comment to reflect this behavioral change.